### PR TITLE
Improve shell-macros.cfg to be user independent

### DIFF
--- a/shell-macros.cfg
+++ b/shell-macros.cfg
@@ -1,6 +1,6 @@
 ## Compile boards firmware
 [gcode_shell_command compile_binaries]
-command: /home/pi/printer_data/config/3dwork-klipper/scripts/compile-binaries.sh
+command: bash -c '~/printer_data/config/3dwork-klipper/scripts/compile-binaries.sh'
 timeout: 2400.
 verbose: True
 
@@ -22,7 +22,7 @@ gcode:
 
 ## Klipper Config backup to Github
 [gcode_shell_command backup_cfg_github]
-command: sh /home/pi/printer_data/config/3dwork-klipper/scripts/3dwork-autocommit.sh
+command: bash -c '~/printer_data/config/3dwork-klipper/scripts/3dwork-autocommit.sh'
 timeout: 30.
 verbose: True
 
@@ -33,7 +33,7 @@ gcode:
 
 ## Change hostname
 [gcode_shell_command change_hostname]
-command: /home/pi/printer_data/config/3dwork-klipper/scripts/change-hostname.sh
+command: bash -c '~/printer_data/config/3dwork-klipper/scripts/change-hostname.sh'
 timeout: 10.
 
 [gcode_macro CHANGE_HOSTNAME]


### PR DESCRIPTION
Modificamos el fichero 'shell-macros.cfg' para permitir que se pueda ejecutar con cualquier usuario, no solo 'pi'

Fuente: https://github.com/dw-0/kiauh/issues/484