### PR TITLE
Reparar error en definición de bucles en macros_filament_basics.cfg

### DIFF
--- a/macros/macros_filament_basics.cfg
+++ b/macros/macros_filament_basics.cfg
@@ -50,7 +50,7 @@ gcode:
      M117 ERROR max_extrude_only_distance
      RESPOND MSG="Max Extrude Only Distance minor to Unload Lengh... Setting Unload Lengh to Max Extrude Only Distance... Please set your [extruder] section to correct max_extrude_only_distance"
 
-     {% for 0 in range((unload_length / max_extrude_only_distance)|int) %}
+     {% for i in range((unload_length / max_extrude_only_distance)|int) %}
         G1 E-{max_extrude_only_distance} F{unload_speed}
      {% endfor %}
      G1 E-{unload_length % max_extrude_only_distance} F{unload_speed}
@@ -90,7 +90,7 @@ gcode:
      M117 ERROR max_extrude_only_distance
      RESPOND MSG="Max Extrude Only Distance minor to Load Lengh... Setting Load Lengh to Max Extrude Only Distance... Please set your [extruder] section to correct max_extrude_only_distance"
 
-     {% for 0 in range((load_length / max_extrude_only_distance)|int) %}
+     {% for i in range((load_length / max_extrude_only_distance)|int) %}
         G1 E{max_extrude_only_distance} F{load_speed}
      {% endfor %}
      G1 E{load_length % max_extrude_only_distance} F{load_speed}


### PR DESCRIPTION
En el cambio de ayer en **macros_filament_basics.cfg**, se definían los bucles con una variable "0", y jinja2 no permite tal cosa (tampoco Python):
`     {% for 0 in range(...`