### PR TITLE
Improve macros_filament_basics to be more flexible in the RatOS style

### DIFF
--- a/macros/macros_filament_basics.cfg
+++ b/macros/macros_filament_basics.cfg
@@ -14,20 +14,28 @@
 [gcode_macro M600]
 description: Executes a color change by pausing the printer an unloading the filament.\nEjecuta un cambio de color pausando la impresora y descargando el filamento.
 gcode:
+  _USER_M600_START
   PAUSE
   UNLOAD_FILAMENT
   M117 {printer["gcode_macro LANGUAGE_GLOBAL_VARS"].msg_m600_info}
   RESPOND MSG="{printer["gcode_macro LANGUAGE_GLOBAL_VARS"].msg_m600_info}"
+  _USER_M600_END
+
+[gcode_macro _USER_M600_START]
+gcode:
+
+[gcode_macro _USER_M600_END]
+gcode:
 
 [gcode_macro UNLOAD_FILAMENT]
 description: Unloads the filament. Note: be careful with PETG, make sure you inspect the tip of your filament before reloading to avoid jams.\N Descarga el filamento. Nota: cuidado con el PETG, asegurate de inspeccionar la punta del filamento antes de recargar para evitar atascos.
 gcode:
+  _USER_UNLOAD_FILAMENT_START
   SAVE_GCODE_STATE NAME=unload_state
   G91
   {% if params.TEMP is defined or not printer.extruder.can_extrude %}
     M117 {printer["gcode_macro LANGUAGE_GLOBAL_VARS"].msg_heating_extruder}
     RESPOND MSG="{printer["gcode_macro LANGUAGE_GLOBAL_VARS"].msg_heating_extruder}"
-
     # Heat up hotend to provided temp or 220 as default as that should work OK with most filaments.
     M104 S{params.TEMP|default(220, true)}
     TEMPERATURE_WAIT SENSOR=extruder MINIMUM={params.TEMP|default(220, true)}
@@ -47,33 +55,37 @@ gcode:
   G0 E-15 F3600 # Extract back fast in to the cold zone
   
   {% if unload_length > max_extrude_only_distance %}
-     M117 ERROR max_extrude_only_distance
-     RESPOND MSG="Max Extrude Only Distance minor to Unload Lengh... Setting Unload Lengh to Max Extrude Only Distance... Please set your [extruder] section to correct max_extrude_only_distance"
-
-     {% for i in range((unload_length / max_extrude_only_distance)|int) %}
-        G1 E-{max_extrude_only_distance} F{unload_speed}
-     {% endfor %}
-     G1 E-{unload_length % max_extrude_only_distance} F{unload_speed}
-   {% else %}
-     G1 E-{unload_length} F{unload_speed}
-   {% endif %}
+    M117 ERROR max_extrude_only_distance
+    RESPOND MSG="Max Extrude Only Distance minor to Unload Lengh... Setting Unload Lengh to Max Extrude Only Distance... Please set your [extruder] section to correct max_extrude_only_distance"
+    {% for i in range((unload_length / max_extrude_only_distance)|int) %}
+      G1 E-{max_extrude_only_distance} F{unload_speed}
+    {% endfor %}
+      G1 E-{unload_length % max_extrude_only_distance} F{unload_speed}
+  {% else %}
+    G1 E-{unload_length} F{unload_speed}
+  {% endif %}
 
   M117 {msg_unload_ok}
   RESPOND MSG="{msg_unload_ok ~ msg_unload_ok_tip}"
-
   RESTORE_GCODE_STATE NAME=unload_state
+  _USER_UNLOAD_FILAMENT_END
+
+[gcode_macro _USER_UNLOAD_FILAMENT_START]
+gcode:
+
+[gcode_macro _USER_UNLOAD_FILAMENT_END]
+gcode:
 
 [gcode_macro LOAD_FILAMENT]
 description: Loads new filament. Note: be careful with PETG, make sure you inspect the tip of your filament before loading to avoid jams.\n Carga filamento nuevo. Nota: cuidado con el PETG, asegurate de inspeccionar la punta del filamento antes de cargarlo para evitar atascos.
 gcode:
+  _USER_LOAD_FILAMENT_START
   SAVE_GCODE_STATE NAME=load_state
   G91
   # Heat up hotend to provided temp or 220 as default as that should work OK with most filaments.
   {% if params.TEMP is defined or not printer.extruder.can_extrude %}
-    
     M117 {printer["gcode_macro LANGUAGE_GLOBAL_VARS"].msg_heating_extruder}
     RESPOND MSG="{printer["gcode_macro LANGUAGE_GLOBAL_VARS"].msg_heating_extruder}"
-
     M104 S{params.TEMP|default(220, true)}
     TEMPERATURE_WAIT SENSOR=extruder MINIMUM={params.TEMP|default(220, true)}
   {% endif %}
@@ -87,16 +99,15 @@ gcode:
 
   # Load the filament into the hotend area.
   {% if load_length > max_extrude_only_distance %}
-     M117 ERROR max_extrude_only_distance
-     RESPOND MSG="Max Extrude Only Distance minor to Load Lengh... Setting Load Lengh to Max Extrude Only Distance... Please set your [extruder] section to correct max_extrude_only_distance"
-
-     {% for i in range((load_length / max_extrude_only_distance)|int) %}
-        G1 E{max_extrude_only_distance} F{load_speed}
-     {% endfor %}
-     G1 E{load_length % max_extrude_only_distance} F{load_speed}
-   {% else %}
-     G1 E{load_length} F{load_speed}
-   {% endif %}
+    M117 ERROR max_extrude_only_distance
+    RESPOND MSG="Max Extrude Only Distance minor to Load Lengh... Setting Load Lengh to Max Extrude Only Distance... Please set your [extruder] section to correct max_extrude_only_distance"
+    {% for i in range((load_length / max_extrude_only_distance)|int) %}
+      G1 E{max_extrude_only_distance} F{load_speed}
+    {% endfor %}
+    G1 E{load_length % max_extrude_only_distance} F{load_speed}
+  {% else %}
+    G1 E{load_length} F{load_speed}
+  {% endif %}
 
   # Wait a secod
   G4 P1000
@@ -107,5 +118,11 @@ gcode:
 
   M117 {printer["gcode_macro LANGUAGE_GLOBAL_VARS"].msg_load_ok}
   RESPOND MSG="{printer["gcode_macro LANGUAGE_GLOBAL_VARS"].msg_load_ok}"
-
   RESTORE_GCODE_STATE NAME=load_state
+  _USER_LOAD_FILAMENT_END
+
+[gcode_macro _USER_LOAD_FILAMENT_START]
+gcode:
+
+[gcode_macro _USER_LOAD_FILAMENT_END]
+gcode:


### PR DESCRIPTION
¡Hola! Hacemos el fichero macros_filament_basics al estilo RatOS. Viene genial para hacer cositas antes del M600 (o después), por ejemplo un BEEP, o lo que el usuario desee.

¡Muchas gracias!