### PR TITLE
Fix CLEAN_NOZZLE is defined and improve logging about it

### DIFF
--- a/macros/macros_print_start_print.cfg
+++ b/macros/macros_print_start_print.cfg
@@ -54,11 +54,14 @@ gcode:
   
   # Clear Nozzle
   {% if printer["gcode_macro GLOBAL_VARS"].clean_nozzle in (1,2) %}
-    {% if printer["gcode_macro clean_nozzle"] is defined %}
+    {% if printer["gcode_macro CLEAN_NOZZLE"] is defined %}
       CLEAN_NOZZLE
       {% if printer["gcode_macro GLOBAL_VARS"].clean_nozzle == 2 %}
         G28 Z
       {% endif %}
+    {% else %}
+      M117 {printer["gcode_macro LANGUAGE_GLOBAL_VARS"].msg_clean_nozzle_not_defined}
+      RESPOND MSG="{printer["gcode_macro LANGUAGE_GLOBAL_VARS"].msg_clean_nozzle_not_defined}"
     {% endif %}
   {% endif %}
 

--- a/macros/macros_var_globals.cfg
+++ b/macros/macros_var_globals.cfg
@@ -86,6 +86,7 @@ variable_msg_heating_chamber=""
 variable_msg_ztilt=""
 variable_msg_ztilt_homingz=""
 variable_msg_ztilt_notenabled=""
+variable_msg_clean_nozzle_not_defined=""
 # Used - macros_print_bed_mesht.cfg
 variable_msg_bedmesh_newmesh=""
 variable_msg_bedmesh_storedmesh=""
@@ -145,6 +146,7 @@ gcode:
       SET_GCODE_VARIABLE MACRO=LANGUAGE_GLOBAL_VARS VARIABLE=msg_ztilt VALUE='"Adjusting Z tilt..."'
       SET_GCODE_VARIABLE MACRO=LANGUAGE_GLOBAL_VARS VARIABLE=msg_ztilt_homingz VALUE='"Rehoming Z after Z tilt adjustment..."'
       SET_GCODE_VARIABLE MACRO=LANGUAGE_GLOBAL_VARS VARIABLE=msg_ztilt_notenabled VALUE='"Z tilt not enabled in your configuration..."'
+      SET_GCODE_VARIABLE MACRO=LANGUAGE_GLOBAL_VARS VARIABLE=msg_clean_nozzle_not_defined VALUE='"CLEAN_NOZZLE ignored because it is not defined in your configuration. Please define it"'
       # Used - macros_print_bed_mesht.cfg
       SET_GCODE_VARIABLE MACRO=LANGUAGE_GLOBAL_VARS VARIABLE=msg_bedmesh_adantative_invalidcoordinates VALUE='"CALIBRATE_ADAPTIVE_MESH: Invalid coordinates received. Please check your slicer settings. Falling back to full bed mesh."'
       # Used - shell_macros.cfg
@@ -187,6 +189,7 @@ gcode:
       SET_GCODE_VARIABLE MACRO=LANGUAGE_GLOBAL_VARS VARIABLE=msg_ztilt VALUE='"Ajustando Z tilt..."'
       SET_GCODE_VARIABLE MACRO=LANGUAGE_GLOBAL_VARS VARIABLE=msg_ztilt_homingz VALUE='"Home Z despues ajuste Z tilt..."'
       SET_GCODE_VARIABLE MACRO=LANGUAGE_GLOBAL_VARS VARIABLE=msg_ztilt_notenabled VALUE='"Z tilt no habilitado en tu configuracion..."'
+      SET_GCODE_VARIABLE MACRO=LANGUAGE_GLOBAL_VARS VARIABLE=msg_clean_nozzle_not_defined VALUE='"CLEAN_NOZZLE ignorado porque no esta definido en tu configuracion. Por favor, definalo"'
       # Used - macros_print_bed_mesht.cfg
       SET_GCODE_VARIABLE MACRO=LANGUAGE_GLOBAL_VARS VARIABLE=msg_bedmesh_adantative_invalidcoordinates VALUE='"CALIBRATE_ADAPTIVE_MESH: Coordenadas invalidas. Revisa la configuracion de tu laminador. Usando coordenadas normales bed mesh."'
       # Used - shell_macros.cfg


### PR DESCRIPTION
Pequeño arreglo en la macro de START_PRINT para que funcione el CLEAN_NOZZLE. Además se han incluido mensajes aclaratorios para ayudar al usuario, de cara a no tener definida la macro.